### PR TITLE
fix: try fix redis exporter labels

### DIFF
--- a/exporters/redis/values.yaml
+++ b/exporters/redis/values.yaml
@@ -8,7 +8,6 @@ tolerations:
     value: "internal"
     effect: "NoSchedule"
 labels:
-  prometheus.io/path: "/metrics"
   prometheus.io/port: "9121"
   prometheus.io/scrape: "true"
 redisAddressConfig:


### PR DESCRIPTION
the default value is `/metrics`